### PR TITLE
Use viz id from visualizations api

### DIFF
--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -80,13 +80,25 @@ if (user_data && user_data.feature_flags && user_data.feature_flags.indexOf('bbg
               this._renderListFooter());
     },
 
-    _isDatasetLocal: function(name, callback) {
+    /*
+     * Retrieve information about a dataset called `name`.
+     * The callback is called with the following arguments:
+     *  arg0 - true if the dataset is of type 'table', false otherwise
+     *  arg1 - the visualization id of the dataset
+     *  arg2 - true if the dataset is from the data lib, false otherwise
+     */
+    _retrieveDatasetInfo: function(name, callback) {
       $.ajax({
-        url: "../../api/v1/viz?q=" + name + "&type=table"
+        url: "../../api/v1/viz?q=" + name + "&types=table,remote"
       })
       .done(function(response) {
         try {
-          callback(response != null && response.total_entries === 1 && response.visualizations[0].name === name);
+          // Note that this only works if the following assumptions are correct:
+          // 1. Any viz that is of type 'remote' is from the datalib
+          // 2. Any viz that is of type 'table' and has synchronization != null is a table from the datalib
+          callback(response.visualizations[0].type === 'table',
+                   response.visualizations[0].id,
+                   response.visualizations[0].type === 'remote' || response.visualizations[0].synchronization != null);
         }
         catch(err) {}
       })
@@ -132,8 +144,10 @@ if (user_data && user_data.feature_flags && user_data.feature_flags.indexOf('bbg
         }
       };
 
-      self._isDatasetLocal(item.dataset, function(is_local) {
-        self.map.layers.bind('add', apply_filter_if_entity);
+      self._retrieveDatasetInfo(item.dataset, function(is_local, viz_id, is_from_datalib) {
+        if (is_from_datalib === true) {
+          self.map.layers.bind('add', apply_filter_if_entity);
+        }
         if (is_local) {
           self.map.addCartodbLayerFromTable(item.dataset, self.user.get('username'), {
             vis: self.vis,
@@ -151,7 +165,7 @@ if (user_data && user_data.feature_flags && user_data.feature_flags.indexOf('bbg
             create_vis: false,
             type: 'remote',
             value: item.dataset,
-            remote_visualization_id: item.id,
+            remote_visualization_id: viz_id,
             size: undefined
           };
           table.backgroundPollingModel.bind('importCompleted', function importCompletedCallback() {


### PR DESCRIPTION
This change only affects users that have 'bbg_new_search' flag enabled, which is no one right now.
- Instead of relying on the ID from elasticsearch (which doesn't work), use the visualization ID we get when we check if the table is local
- Also do some extra checking to make sure the table is in fact coming from the datalib.\

@mbektas would you mind taking a quick look at this?