### PR TITLE
Recover aliases on FDW library imports

### DIFF
--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -160,6 +160,9 @@ module CartoDB
           end
           data = JSON.parse(response.response_body)
           table_visualization_map_id = data['table_visualization']['map_id']
+          table.alias = data['alias']
+          table.schema_alias = data['schema_alias']
+          table.save
 
           # Get remote vis layer configs
           url = "#{remote_base_url}/api/v1/maps/#{table_visualization_map_id}/layers"

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -91,6 +91,16 @@ module Carto
       self.table_id = service.get_table_id
     end
 
+    def schema_alias=(hash)
+      self.alias_columns = (hash || {}).to_json
+    end
+
+    def schema_alias
+      JSON.parse(alias_columns).with_indifferent_access
+    rescue JSON::ParserError, TypeError
+      {}
+    end
+
     private
 
     def fully_qualified_name

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -43,22 +43,25 @@ class Table
   # @see services/importer/lib/importer/column.rb -> RESERVED_WORDS
   # @see config/initializers/carto_db.rb -> RESERVED_COLUMN_NAMES
   RESERVED_COLUMN_NAMES = %W{ oid tableoid xmin cmin xmax cmax ctid ogc_fid }
+
   PUBLIC_ATTRIBUTES = {
-      :id                           => :id,
-      :name                         => :name,
-      :privacy                      => :privacy_text,
-      :schema                       => :schema,
-      :updated_at                   => :updated_at,
-      :rows_counted                 => :rows_estimated,
-      :table_size                   => :table_size,
-      :map_id                       => :map_id,
-      :description                  => :description,
-      :geometry_types               => :geometry_types,
-      :table_visualization          => :table_visualization,
-      :dependent_visualizations     => :serialize_dependent_visualizations,
-      :non_dependent_visualizations => :serialize_non_dependent_visualizations,
-      :synchronization              => :serialize_synchronization
-  }
+    id: :id,
+    name: :name,
+    alias: :alias,
+    schema_alias: :schema_alias,
+    privacy: :privacy_text,
+    schema: :schema,
+    updated_at: :updated_at,
+    rows_counted: :rows_estimated,
+    table_size: :table_size,
+    map_id: :map_id,
+    description: :description,
+    geometry_types: :geometry_types,
+    table_visualization: :table_visualization,
+    dependent_visualizations: :serialize_dependent_visualizations,
+    non_dependent_visualizations: :serialize_non_dependent_visualizations,
+    synchronization: :serialize_synchronization
+  }.freeze
 
   DEFAULT_THE_GEOM_TYPE = 'geometry'
 
@@ -1351,6 +1354,22 @@ class Table
                           table_id: table_id,
                           oid: get_table_id,
                           table_name: name)
+  end
+
+  def alias=(alias_)
+    @user_table.alias = alias_
+  end
+
+  def alias
+    @user_table.alias
+  end
+
+  def schema_alias=(schema_alias)
+    @user_table.schema_alias = schema_alias
+  end
+
+  def schema_alias
+    @user_table.schema_alias
   end
 
   private

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -293,4 +293,14 @@ class UserTable < Sequel::Model
   def actual_row_count
     service.actual_row_count
   end
+
+  def schema_alias=(hash)
+    self.alias_columns = (hash || {}).to_json
+  end
+
+  def schema_alias
+    JSON.parse(alias_columns).with_indifferent_access
+  rescue JSON::ParserError, TypeError
+    {}
+  end
 end

--- a/db/migrate/20170206160007_add_aliases_to_user_tables.rb
+++ b/db/migrate/20170206160007_add_aliases_to_user_tables.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  up do
+    add_column :user_tables, :alias, :text
+    add_column :user_tables, :alias_columns, :text
+  end
+
+  down do
+    drop_column :user_tables, :alias
+    drop_column :user_tables, :alias_columns
+  end
+end

--- a/spec/models/carto/user_table_spec.rb
+++ b/spec/models/carto/user_table_spec.rb
@@ -32,4 +32,52 @@ describe Carto::UserTable do
 
     @user_table.sync_table_id.should eq @user_table.service.get_table_id
   end
+
+  describe('#alias') do
+    before(:each) do
+      @user_table.update_attributes!(alias: nil)
+    end
+
+    after(:all) do
+      @user_table.update_attributes!(alias: nil)
+    end
+
+    it 'sets and gets' do
+      @user_table.alias = 'foo'
+      @user_table.save
+      @user_table.reload.alias.should eq 'foo'
+    end
+  end
+
+  describe('#schema_alias') do
+    let(:schema_alias) do
+      {
+        one_column: 'with alias',
+        another_column: 'with another alias'
+      }.with_indifferent_access
+    end
+
+    before(:each) do
+      @user_table.update_attributes!(schema_alias: {})
+    end
+
+    after(:all) do
+      @user_table.update_attributes!(schema_alias: {})
+    end
+
+    it 'sets and gets' do
+      @user_table.update_attributes!(schema_alias: schema_alias)
+      @user_table.reload.schema_alias.should eq schema_alias
+    end
+
+    it 'ignores format issues' do
+      @user_table.update_attributes!(schema_alias: 'not a hash')
+      @user_table.reload.schema_alias.should(eq({}))
+    end
+
+    it 'ignores nil issues' do
+      @user_table.update_attributes!(schema_alias: nil)
+      @user_table.reload.schema_alias.should(eq({}))
+    end
+  end
 end

--- a/spec/models/user_table_spec.rb
+++ b/spec/models/user_table_spec.rb
@@ -2,9 +2,12 @@
 require_relative '../spec_helper'
 
 describe UserTable do
+  before(:each) do
+    bypass_named_maps
+  end
+
   before(:all) do
     bypass_named_maps
-
     @user = create_user(email: 'admin@cartotest.com', username: 'admin', password: '123456')
 
     @user_table = ::UserTable.new
@@ -36,5 +39,60 @@ describe UserTable do
     @user_table.table_id.should be_nil
 
     @user_table.sync_table_id.should eq @user_table.service.get_table_id
+  end
+
+  describe('#alias') do
+    before(:each) do
+      @user_table.alias = nil
+      @user_table.save!
+    end
+
+    after(:all) do
+      @user_table.alias = nil
+      @user_table.save!
+    end
+
+    it 'sets and gets' do
+      @user_table.alias = 'foo'
+      @user_table.save
+      @user_table.reload.alias.should eq 'foo'
+    end
+  end
+
+  describe('#schema_alias') do
+    let(:schema_alias) do
+      {
+        one_column: 'with alias',
+        another_column: 'with another alias'
+      }.with_indifferent_access
+    end
+
+    before(:each) do
+      @user_table.schema_alias = {}
+      @user_table.save!
+    end
+
+    after(:all) do
+      @user_table.schema_alias = {}
+      @user_table.save!
+    end
+
+    it 'sets and gets' do
+      @user_table.schema_alias = schema_alias
+      @user_table.save!
+      @user_table.reload.schema_alias.should eq schema_alias
+    end
+
+    it 'ignores format issues' do
+      @user_table.schema_alias = 'not a hash'
+      @user_table.save!
+      @user_table.reload.schema_alias.should(eq({}))
+    end
+
+    it 'ignores nil issues' do
+      @user_table.schema_alias = nil
+      @user_table.save!
+      @user_table.reload.schema_alias.should(eq({}))
+    end
   end
 end


### PR DESCRIPTION
## Context

Aliases in Library datasets were lost on import. This was due to:

1. Alias data was not exposed through the `TablesController` endpoint (missing public attributes in `app/models/table.rb`).
2. Alias data was not recovered and saved during FDW import in `app/connectors/importer.rb`

This PR addresses 1. and 2. so alias information can be recovered after a library import.

Apart from the fixing code, the PR contains:

1. Style adjustments (new Ruby Hash syntax in `app/connectors/importer.rb:48`)
2. Tests for the new `alias` and `alias_columns` getter/setters in both Sequel and ActiveRecords models of `UserTable`.
3. A migration that creates `user_tables.alias` and `user_tables.alias_columns` when migrated and drops them when rollbacked. 

## Notes

To run the migration, `RAILS_ENV=<env> bundle exec rake db:migrate` must be run. If the columns have been created manually (to the back of the migrator), an error might rise due to conflict. This issue can be resolved manually.

## Acceptance

In order to test that this code is running, the minimum acceptance suggested is:

1. Create a new dataset in the data library account.
2. Add a table name alias to the dataset.
3. Add a column alias to some column in the dataset.
4. Run the invalidation rake task so that other users will see the new dataset (`RAILS_ENV=<env> bundle exec rake cartodb:remotes:invalidate_common_data`)
5. Login into another account and search for the new library dataset in "Bloomberg Data"
6. Connect the dataset

Import should be successful and upon opening the newly imported dataset, the alias information for table name and columns should be there.

Also, it's nice to verify that other imports (URL, File) still work.