### PR TITLE
Show original name for mapsdata user

### DIFF
--- a/lib/assets/javascripts/cartodb/dashboard/datasets/datasets_item.js
+++ b/lib/assets/javascripts/cartodb/dashboard/datasets/datasets_item.js
@@ -104,7 +104,7 @@ module.exports = cdb.core.View.extend({
 
   _title: function (title, alias, user) {
     if (alias && user.featureEnabled('aliases')) {
-      return alias + ' (' + title ')';
+      return alias + ' (' + title + ')';
     } else {
       return alias || title;
     }

--- a/lib/assets/javascripts/cartodb/dashboard/datasets/datasets_item.js
+++ b/lib/assets/javascripts/cartodb/dashboard/datasets/datasets_item.js
@@ -43,7 +43,11 @@ module.exports = cdb.core.View.extend({
     var d = {
       isRaster:                vis.get('kind') === 'raster',
       geometryType:            table.statsGeomColumnTypes().length > 0 ? table.statsGeomColumnTypes()[0] : '',
-      title:                   vis.get('table').name_alias || vis.get('display_name') || vis.get('name'),
+      title:                   this._title(
+                                 vis.get('display_name') || vis.get('name'),
+                                 vis.get('table').name_alias,
+                                 this.user
+                               ),
       datasetUrl:              encodeURI(url),
       isOwner:                 vis.permission.isOwner(this.user),
       owner:                   vis.permission.owner.renderData(this.user),
@@ -96,6 +100,14 @@ module.exports = cdb.core.View.extend({
     this.$el.find('.RowCheckbox')[ selected ? 'addClass' : 'removeClass' ]('is--selected');
 
     return this;
+  },
+
+  _title: function (title, alias, user) {
+    if (alias && user.featureEnabled('aliases')) {
+      return alias + ' (' + title ')';
+    } else {
+      return alias || title;
+    }
   },
 
   _initBinds: function() {

--- a/lib/assets/javascripts/cartodb/dashboard/datasets/remote_datasets_item.js
+++ b/lib/assets/javascripts/cartodb/dashboard/datasets/remote_datasets_item.js
@@ -84,7 +84,7 @@ module.exports = DatasetsItem.extend({
 
   _title: function (title, alias, user) {
     if (alias && user.featureEnabled('aliases')) {
-      return alias + ' (' + title ')';
+      return alias + ' (' + title + ')';
     } else {
       return alias || title;
     }

--- a/lib/assets/javascripts/cartodb/dashboard/datasets/remote_datasets_item.js
+++ b/lib/assets/javascripts/cartodb/dashboard/datasets/remote_datasets_item.js
@@ -39,7 +39,11 @@ module.exports = DatasetsItem.extend({
     var d = {
       isRaster:                vis.get('kind') === 'raster',
       geometryType:            table.statsGeomColumnTypes().length > 0 ? table.statsGeomColumnTypes()[0] : '',
-      title:                   vis.get('display_name') || vis.get('name'),
+      title:                   this._title(
+                                 vis.get('name'),
+                                 vis.get('display_name'),
+                                 this.user
+                               ),
       source:                  source,
       description:             description,
       timeDiff:                moment(vis.get('updated_at')).fromNow(),
@@ -76,6 +80,14 @@ module.exports = DatasetsItem.extend({
     this._renderTooltips();
 
     return this;
+  },
+
+  _title: function (title, alias, user) {
+    if (alias && user.featureEnabled('aliases')) {
+      return alias + ' (' + title ')';
+    } else {
+      return alias || title;
+    }
   },
 
   _renderTooltips: function() {


### PR DESCRIPTION
## Context

This PR brings the ability to see original dataset names in parenthesis for maps data (and all aliases feature flag users).

![screen shot 2017-03-17 at 15 55 23](https://cloud.githubusercontent.com/assets/4222826/24048803/45cdc9dc-0b2a-11e7-8950-eaea1b7a9455.png)


Please review @mbektas 