### PR TITLE
[ALIASES] Default to dataset name

### DIFF
--- a/app/services/visualization/common_data_service.rb
+++ b/app/services/visualization/common_data_service.rb
@@ -66,7 +66,8 @@ module CartoDB
               if visualization.update_remote_data(
                   Member::PRIVACY_PUBLIC,
                   dataset['description'], dataset['tags'], dataset['license'],
-                  dataset['source'], dataset['attributions'], dataset['name_alias'] || dataset['display_name'], dataset['exportable'], dataset['export_geom'], dataset['category'])
+                  dataset['source'], dataset['attributions'], dataset['name_alias'] || dataset['display_name'],
+                  dataset['exportable'], dataset['export_geom'], dataset['category'])
                 visualization.store
                 updated += 1
               else
@@ -76,7 +77,8 @@ module CartoDB
               visualization = Member.remote_member(
                 dataset['name'], user.id, Member::PRIVACY_PUBLIC,
                 dataset['description'], dataset['tags'], dataset['license'],
-                dataset['source'], dataset['attributions'], dataset['name_alias'] || dataset['display_name'], dataset['exportable'], dataset['export_geom'], dataset['category']).store
+                dataset['source'], dataset['attributions'], dataset['name_alias'] || dataset['display_name'],
+                dataset['exportable'], dataset['export_geom'], dataset['category']).store
               added += 1
             end
 

--- a/app/services/visualization/common_data_service.rb
+++ b/app/services/visualization/common_data_service.rb
@@ -66,7 +66,7 @@ module CartoDB
               if visualization.update_remote_data(
                   Member::PRIVACY_PUBLIC,
                   dataset['description'], dataset['tags'], dataset['license'],
-                  dataset['source'], dataset['attributions'], dataset['name_alias'], dataset['exportable'], dataset['export_geom'], dataset['category'])
+                  dataset['source'], dataset['attributions'], dataset['name_alias'] || dataset['display_name'], dataset['exportable'], dataset['export_geom'], dataset['category'])
                 visualization.store
                 updated += 1
               else
@@ -76,7 +76,7 @@ module CartoDB
               visualization = Member.remote_member(
                 dataset['name'], user.id, Member::PRIVACY_PUBLIC,
                 dataset['description'], dataset['tags'], dataset['license'],
-                dataset['source'], dataset['attributions'], dataset['name_alias'], dataset['exportable'], dataset['export_geom'], dataset['category']).store
+                dataset['source'], dataset['attributions'], dataset['name_alias'] || dataset['display_name'], dataset['exportable'], dataset['export_geom'], dataset['category']).store
               added += 1
             end
 


### PR DESCRIPTION
## Context

Previous behaviour was to rely on `display_name`, and this value is never null. As of https://github.com/bloomberg/cartodb/commit/20e0c6030de5f9dec148913a53f6824dace6be73#diff-3a1beb0650f95eb616c3a6c2e67aae9f, it relies on `alias_name`, which can be null. This PR just defaults to `display_name` if `alias_name` is null, but a good solution should fix null-sucesptible pieces that are breaking.