### PR TITLE
[ALIASES] Hide original name for non-mapsdata users

### DIFF
--- a/lib/assets/javascripts/cartodb/table/tableview.js
+++ b/lib/assets/javascripts/cartodb/table/tableview.js
@@ -190,7 +190,8 @@
         var table_title_alias = (this.model.get('name_alias')) ? this.model.get('name_alias') : null;
         thead.prepend(cdb.templates.getTemplate('table/views/table_title')(
           {
-            'tablename': this.model.get('name'), 
+            'tablename': this.model.get('name'),
+            'alias_feature_flag': this.user.featureEnabled('aliases'),
             'titleAlias': table_title_alias
           }
         ));

--- a/lib/assets/javascripts/cartodb/table/views/table_title.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/table_title.jst.ejs
@@ -1,6 +1,11 @@
 <div>
 <% if (titleAlias) { %>
-    <h2 class="table_title"><%- titleAlias %> (<%- tablename %>)</h2>  
+    <h2 class="table_title">
+        <%- titleAlias %> 
+        <% if (alias_feature_flag) { %>
+            (<%- tablename %>)
+        <% } %>
+    </h2>  
 <% } else {%>
     <h2 class="table_title"><%- tablename %></h2>
 <% } %>


### PR DESCRIPTION
## Context

This PR introduces changes so that only the maps data user will the original dataset name in parenthesis in a dataset.

Please review @mbektas 