### PR TITLE
[ALIASES] Fix categories dropdown

### DIFF
--- a/vendor/assets/javascripts/select2.min.js
+++ b/vendor/assets/javascripts/select2.min.js
@@ -833,7 +833,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     process=function(element, collection) {
                         var group;
                         if (element.is("option")) {
-                            if (query.matcher(term, (element.attr('alias') !== 'null') ? element.attr('alias') : element.text(), element)) {
+                            if (query.matcher(term, element.attr('alias') ? element.attr('alias') : element.text(), element)) {
                                 collection.push({id:element.attr("value"), text:element.text(), element: element.get(), css: element.attr("class"), alias: (element.attr('alias') !== 'null') ? element.attr('alias') : undefined});
                             }
                         } else if (element.is("optgroup")) {


### PR DESCRIPTION
## Context

This PR fixes an issue that prevented the categories dropdown from showing in the side panel for "dataset info".

## Acceptance

- [ ] See category dropdown displays
- [ ] See subcategory dropdown displays
- [ ] See that column selector dropdown shows aliases and normal columns in filters


Please review @mbektas 