### PR TITLE
[Aliases] Change "Delete dataset", "Connecting dataset" and "Delete column" templates to show aliases

### DIFF
--- a/lib/assets/javascripts/cartodb/common/background_polling/models/upload_model.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/models/upload_model.js
@@ -19,6 +19,7 @@ module.exports = Backbone.Model.extend({
   defaults: {
     type: '',
     value: '',
+    aliasedValue: '',
     interval: 0,
     privacy: '',
     progress: 0,

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/create_loading.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/create_loading.js
@@ -23,12 +23,15 @@ module.exports = cdb.core.View.extend({
 
   render: function() {
     var currentImport = this.model.get('currentImport');
+    var upl = currentImport && currentImport.upl;
+    var currentImportName = upl && (upl.get('aliasedValue') || upl.get('service_item_id') || upl.get('value'))
+
     var d = {
       createModelType: this.createModel.get('type'),
       type: this.model.get('type'),
       state: this.model.get('state'),
       currentImport: currentImport,
-      currentImportName: currentImport && ( currentImport.upl.get('service_item_id') || currentImport.upl.get('value') ),
+      currentImportName: currentImportName,
       tableIdsArray: this.model.get('tableIdsArray'),
       selectedDatasets: this.createModel.selectedDatasets,
       upgradeUrl: window.upgrade_url,

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
@@ -252,7 +252,7 @@ module.exports = cdb.core.Model.extend({
       var d = {
         create_vis: false,
         type: 'remote',
-        value: mdl.get('name'),
+        value: mdl.get('display_name') || mdl.get('name'),
         remote_visualization_id: mdl.get('id'),
         size: mdl.get('external_source') ? mdl.get('external_source').size : undefined
       };

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
@@ -252,7 +252,8 @@ module.exports = cdb.core.Model.extend({
       var d = {
         create_vis: false,
         type: 'remote',
-        value: mdl.get('display_name') || mdl.get('name'),
+        value: mdl.get('name'),
+        aliasedValue: mdl.get('display_name'),
         remote_visualization_id: mdl.get('id'),
         size: mdl.get('external_source') ? mdl.get('external_source').size : undefined
       };

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
@@ -24,9 +24,8 @@ module.exports = BaseDialog.extend({
   },
 
   _initViews: function() {
-
     this.table = this.options.table;
-    this.column = this.options.column;
+    this.column = this.options.table.get('column_aliases')[this.options.column] || this.options.column;
 
     this._panes = new cdb.ui.common.TabPane({
       el: this.el
@@ -57,7 +56,7 @@ module.exports = BaseDialog.extend({
 
   ok: function() {
     this._panes.active('loading');
-    this.table.deleteColumn(this.column);
+    this.table.deleteColumn(this.options.column);
     this.close();
   }
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
@@ -24,8 +24,13 @@ module.exports = BaseDialog.extend({
   },
 
   _initViews: function() {
+    var column_alias = null;
+    if (this.options.table.get('column_aliases') && this.options.table.get('column_aliases')[this.options.column]) {
+      column_alias = this.options.table.get('column_aliases')[this.options.column];
+    }
+
     this.table = this.options.table;
-    this.column = this.options.table.get('column_aliases')[this.options.column] || this.options.column;
+    this.column = column_alias || this.options.column;
 
     this._panes = new cdb.ui.common.TabPane({
       el: this.el

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -65,6 +65,7 @@ module.exports = BaseDialog.extend({
     // An entity can be an User or Organization
     var affectedEntities = this._viewModel.affectedEntities();
     var affectedVisData = this._viewModel.affectedVisData();
+
     return cdb.templates.getTemplate('common/dialogs/delete_items_view_template')({
       firstItemName: this._getFirstItemName(),
       selectedCount: this._viewModel.length,
@@ -147,6 +148,7 @@ module.exports = BaseDialog.extend({
     if (!this.options.viewModel) return;
 
     var firstItem = this.options.viewModel.at(0);
+
     if (firstItem) {
       return firstItem.get('table').name_alias || firstItem.get("name");
     }

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -65,7 +65,6 @@ module.exports = BaseDialog.extend({
     // An entity can be an User or Organization
     var affectedEntities = this._viewModel.affectedEntities();
     var affectedVisData = this._viewModel.affectedVisData();
-    
     return cdb.templates.getTemplate('common/dialogs/delete_items_view_template')({
       firstItemName: this._getFirstItemName(),
       selectedCount: this._viewModel.length,

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -65,7 +65,7 @@ module.exports = BaseDialog.extend({
     // An entity can be an User or Organization
     var affectedEntities = this._viewModel.affectedEntities();
     var affectedVisData = this._viewModel.affectedVisData();
-
+    
     return cdb.templates.getTemplate('common/dialogs/delete_items_view_template')({
       firstItemName: this._getFirstItemName(),
       selectedCount: this._viewModel.length,
@@ -148,9 +148,8 @@ module.exports = BaseDialog.extend({
     if (!this.options.viewModel) return;
 
     var firstItem = this.options.viewModel.at(0);
-
     if (firstItem) {
-      return firstItem.get("name");
+      return firstItem.get('table').name_alias || firstItem.get("name");
     }
   }
 


### PR DESCRIPTION
## Context

This PR changes the following templates to include pertinent aliases:

- Connecting dataset
- Delete dataset
- Delete column

## Acceptance

- [ ] Check that "Delete dataset" modal show's the dataset's name alias if available
- [ ] Check that "Delete dataset" modal show's the dataset's original name if alias unavailable
- [ ] Check that "Connecting dataset" modal show's the dataset's name alias if available
- [ ] Check that "Connecting dataset" modal show's the dataset's original name if alias unavailable
- [ ] Check that "Delete column" modal show's the column's name alias if available
- [ ] Check that "Delete column" modal show's the column's original name if alias unavailable

Please review @mbektas 