### PR TITLE
Fix "cartodb_id" showing in "Analyse" dropdowns

### DIFF
--- a/lib/assets/javascripts/cartodb/models/wizard.js
+++ b/lib/assets/javascripts/cartodb/models/wizard.js
@@ -85,12 +85,11 @@ cdb.admin.FormSchema = cdb.core.Model.extend({
           for(var i in types) {
             var type = types[i];
             var columns = self.table.columnNamesByTypeAsObj(type);
-
             // Used to sort be Alias first.
+            columns = _.filter(columns, function(item) { return item[0] !== 'cartodb_id'});
             columns = _.sortBy(columns, function (r) {
                 return (r[2] || r[0]).toLowerCase();
             });
-
             extra = extra.concat(
               _.without(columns, 'cartodb_id')
             )


### PR DESCRIPTION
## Context

This PR prevents `cartodb_id` column from showing in the "Analyse" wizards' dropdown menus for column selection.

## Acceptance

- [ ] Check that the `cartodb_id` column doesn't appear anywhere in dropdowns.

Please review, @mbektas 