### PR TITLE
Use original names in sql generator

### DIFF
--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -728,7 +728,7 @@ cdb.admin.CartoStyles = Backbone.Model.extend({
       var changed = {};
       this.properties.bind('change', function() {
         changed = this.properties.changedAttributes();
-        var tableAliasSchema = this.table.get('schema_alias');
+        var tableAliasSchema = this.table.get('column_aliases');
         if(changed.property){
           for(var k in tableAliasSchema){
             if(tableAliasSchema[k] === changed.property){
@@ -745,7 +745,7 @@ cdb.admin.CartoStyles = Backbone.Model.extend({
         }
       }, this);
       var thisProperties = this.get('properties');
-      var tableAliasSchema = this.table.get('schema_alias');
+      var tableAliasSchema = this.table.get('column_aliases');
       for(var key in thisProperties){
         for(var key2 in tableAliasSchema){
           if(thisProperties[key] === tableAliasSchema[key2]){

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -449,7 +449,7 @@
 
       var aliasList = this.get('column_aliases');
 
-      // When new table is created the schema_alias comes back as a string and
+      // When new table is created the column_aliases comes back as a string and
       // not an object. Convert into object if typeof is not object
       aliasList = (typeof aliasList === 'object') ? aliasList : {};
       if (newAliasName) {


### PR DESCRIPTION
Fixes https://github.com/cartodb-org/cartodb/issues/172

## Context

This PR fixes a bug where aliased names where being used to generate the SQL query for wizards in "Analyse".

## Acceptance

- [ ] Check that you can use a aliased column as chrorpleth column when switching from "Simple"


Please review @mbektas 