### PR TITLE
Add parserlocks table to carto_db_development for parser sync

### DIFF
--- a/db/migrate/20170523112324_add_parserlocks.rb
+++ b/db/migrate/20170523112324_add_parserlocks.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+    change do
+        create_table(:parserlocks) do
+            String :parser, :primary_key=>true
+            String :hostname
+            Integer :pid
+            DateTime :update_timestamp
+        end
+    end
+    down do
+        drop_table(:parserlocks)
+    end
+end


### PR DESCRIPTION
Migration script to add parserlocks table to carto_db_development.  This table is used to sync parsers for MAPS<GO>