### PR TITLE
Adding check for a valid user

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -195,6 +195,11 @@ class Table
   # it also needs the user used to search a table when the
   # name is not qualified
   def self.get_all_by_names(names, viewer_user)
+    if (!viewer_user)
+      CartoDB.notify_error("get_all_by_names user doesn't exist")
+      return []
+    end
+
     names.map { |t|
       user_id = viewer_user.id
       table_name, table_schema = Table.table_and_schema(t)
@@ -210,6 +215,11 @@ class Table
 
   # TODO: REFACTOR THIS patch introduced to continue with #3664
   def self.get_all_user_tables_by_names(names, viewer_user)
+    if (!viewer_user)
+      CartoDB.notify_error("get_all_by_names user doesn't exist")
+      return []
+    end
+
     names.map { |t|
       user_id = viewer_user.id
       table_name, table_schema = Table.table_and_schema(t)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -196,7 +196,7 @@ class Table
   # name is not qualified
   def self.get_all_by_names(names, viewer_user)
     if (!viewer_user)
-      CartoDB.notify_error("get_all_by_names user doesn't exist")
+      CartoDB::Logger.error("get_all_by_names user doesn't exist")
       return []
     end
 
@@ -216,7 +216,7 @@ class Table
   # TODO: REFACTOR THIS patch introduced to continue with #3664
   def self.get_all_user_tables_by_names(names, viewer_user)
     if (!viewer_user)
-      CartoDB.notify_error("get_all_by_names user doesn't exist")
+      CartoDB::Logger.error("get_all_by_names user doesn't exist")
       return []
     end
 

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -196,7 +196,7 @@ class Table
   # name is not qualified
   def self.get_all_by_names(names, viewer_user)
     if (!viewer_user)
-      CartoDB::Logger.error("get_all_by_names user doesn't exist")
+      CartoDB::Logger.error(message:"user doesn't exist")
       return []
     end
 
@@ -216,7 +216,7 @@ class Table
   # TODO: REFACTOR THIS patch introduced to continue with #3664
   def self.get_all_user_tables_by_names(names, viewer_user)
     if (!viewer_user)
-      CartoDB::Logger.error("get_all_by_names user doesn't exist")
+      CartoDB::Logger.error(message:"user doesn't exist")
       return []
     end
 

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -76,7 +76,7 @@ module CartoDB
                                           map_id: visualization.map_id
                                         }, table_privacy_changed)
         else
-          CartoDB.notify_error("Visualization user doesn't exist", visualization_id: visualization.id)
+          CartoDB::Logger.error("Visualization user doesn't exist", visualization_id: visualization.id)
         end
       end
 

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -70,10 +70,14 @@ module CartoDB
     # Propagation flow: Table -> Table PrivacyManager -> Visualization -> Visualization NamedMap
     def propagate_to(visualizations, table_privacy_changed = false)
       visualizations.each do |visualization|
-        visualization.store_using_table({
+        if (visualization.user) 
+          visualization.store_using_table({
                                           privacy_text: ::UserTable::PRIVACY_VALUES_TO_TEXTS[privacy],
                                           map_id: visualization.map_id
                                         }, table_privacy_changed)
+        else
+          CartoDB.notify_error("Visualization user doesn't exist", visualization_id: visualization.id)
+        end
       end
 
       self

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -77,7 +77,7 @@ module CartoDB
                                         }, table_privacy_changed)
         else
           CartoDB::Logger.error(message:
-                                "user doesn't exist for visualization #{visualization.name}: #{visualization.id}")
+                                "user doesn't exist for visualization", visualization: visualization)
         end
       end
 

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -76,7 +76,8 @@ module CartoDB
                                           map_id: visualization.map_id
                                         }, table_privacy_changed)
         else
-          CartoDB::Logger.error("Visualization user doesn't exist", visualization_id: visualization.id)
+          CartoDB::Logger.error(message:
+                                "user doesn't exist for visualization #{visualization.name}: #{visualization.id}")
         end
       end
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -753,6 +753,11 @@ module CartoDB
       end
 
       def do_store(propagate_changes = true, table_privacy_changed = false)
+        if (!user) 
+          CartoDB.notify_error("Visualization user doesn't exist", visualization_id: self.id)
+          return self;
+        end
+
         if password_protected?
           raise CartoDB::InvalidMember.new('No password set and required') unless has_password?
         else

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -755,7 +755,7 @@ module CartoDB
       def do_store(propagate_changes = true, table_privacy_changed = false)
         if (!user) 
           CartoDB::Logger.error(message:
-                                "user doesn't exist for visualization #{self.name}: #{self.id}")
+                                "user doesn't exist for visualization ", visualization: self)
           return self
         end
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -754,7 +754,8 @@ module CartoDB
 
       def do_store(propagate_changes = true, table_privacy_changed = false)
         if (!user) 
-          CartoDB::Logger.error("Visualization user doesn't exist", visualization_id: self.id)
+          CartoDB::Logger.error(message:
+                                "user doesn't exist for visualization #{self.name}: #{self.id}")
           return self
         end
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -754,8 +754,8 @@ module CartoDB
 
       def do_store(propagate_changes = true, table_privacy_changed = false)
         if (!user) 
-          CartoDB.notify_error("Visualization user doesn't exist", visualization_id: self.id)
-          return self;
+          CartoDB::Logger.error("Visualization user doesn't exist", visualization_id: self.id)
+          return self
         end
 
         if password_protected?


### PR DESCRIPTION
This is to guard against the orphaned visualization records. i.e. visualizations without any associated owners (users)