### PR TITLE
Replace URI join with more predictable concatentation

### DIFF
--- a/app/services/visualization/common_data_service.rb
+++ b/app/services/visualization/common_data_service.rb
@@ -45,10 +45,7 @@ module CartoDB
         if !common_data_base_url.nil?
           # We set user_domain to nil to avoid duplication in the url for subdomainfull urls. Ie. user.cartodb.com/u/cartodb/...
           params[:user_domain] = nil
-          URI.join(
-              common_data_base_url,
-              CartoDB.path(controller, 'api_v1_visualizations_index', params)
-          ).to_s
+          common_data_base_url + CartoDB.path(controller, 'api_v1_visualizations_index', params)
         elsif !common_data_user.nil?
           CartoDB.url(controller, 'api_v1_visualizations_index', params, common_data_user)
         else


### PR DESCRIPTION
Due to some quirks in [URI.join](https://ruby-doc.org/stdlib-1.9.3/libdoc/uri/rdoc/URI.html#method-c-join) which were missed in local and single host testing, URLs were constructed with missing user domain parameters and caused issues during imports in the dev cluster.  This restores the original, stable behavior for constructing the visualization api URLs and ensures that none of the URL components are truncated.

See [Why is URI.join so counterintuitive?](http://blog.honeybadger.io/why-is-uri-join-so-counterintuitive/) for more info.