### PR TITLE
Remove Geocoding Cost related messages

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_view.js
@@ -24,14 +24,6 @@ module.exports = cdb.core.View.extend({
     );
     this._renderHeader();
     this._renderRows();
-
-    var showCostsInfo = this.model.showCostsInfo();
-    if (showCostsInfo) {
-      this._renderEstimation();
-      this._renderQuota();
-    }
-    this.$('.js-costs-info').toggle(!!showCostsInfo);
-
     this._renderFooter();
     return this;
   },
@@ -50,24 +42,6 @@ module.exports = cdb.core.View.extend({
     this.model.get('rows').chain()
       .map(this._createRowView, this)
       .map(this._appendRowToDOM, this);
-  },
-
-  _renderEstimation: function() {
-    var view = new EstimationView({
-      model: this.model.get('estimation'),
-      userGeocoding: this.model.get('userGeocoding'),
-      hasHardLimit: this.model.hasHardLimit()
-    });
-    this.addView(view);
-    this.$('.js-estimation').append(view.render().el);
-  },
-
-  _renderQuota: function() {
-    var view = new QuotaView({
-      model: this.model.get('userGeocoding')
-    });
-    this.addView(view);
-    this.$('.js-quota').append(view.render().el);
   },
 
   _renderFooter: function() {


### PR DESCRIPTION
This is related to Georeferencing option in MAPS.
We do not need cost/credit information dialog in the UI.