### PR TITLE
FDW unit test fixes

### DIFF
--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -309,7 +309,6 @@ module CartoDB
 
         new_name
       rescue => exception
-        byebug
         CartoDB.notify_debug('Error while renaming at importer', { current_name: current_name, new_name: new_name, rename_attempts: rename_attempts, result: result.inspect, error: exception.inspect}) if rename_attempts == 1
         message = "Silently retrying renaming #{current_name} to #{target_new_name} (current: #{new_name}). ERROR: #{exception}"
         runner.log.append(message)
@@ -366,6 +365,15 @@ module CartoDB
         if common_data_user
           common_data_user.visualizations.where(privacy: 'public', type: 'table', name: table_name).first
         end
+      end
+
+      def common_data_user
+        return @common_data_user if @common_data_user
+
+        common_data_config = Cartodb.config[:common_data]
+        username = common_data_config && common_data_config['username']
+
+        @common_data_user = Carto::User.find_by_username(username)
       end
 
       attr_reader :runner, :table_registrar, :quota_checker, :database, :data_import_id

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -309,6 +309,7 @@ module CartoDB
 
         new_name
       rescue => exception
+        byebug
         CartoDB.notify_debug('Error while renaming at importer', { current_name: current_name, new_name: new_name, rename_attempts: rename_attempts, result: result.inspect, error: exception.inspect}) if rename_attempts == 1
         message = "Silently retrying renaming #{current_name} to #{target_new_name} (current: #{new_name}). ERROR: #{exception}"
         runner.log.append(message)
@@ -362,8 +363,9 @@ module CartoDB
       end
 
       def common_data_table(table_name)
-        @common_data_user ||= Carto::User.find_by_username(Cartodb.config[:common_data]["username"])
-        @common_data_user.visualizations.where(privacy: 'public', type: 'table', name: table_name).first if @common_data_user
+        if common_data_user
+          common_data_user.visualizations.where(privacy: 'public', type: 'table', name: table_name).first
+        end
       end
 
       attr_reader :runner, :table_registrar, :quota_checker, :database, :data_import_id

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -321,7 +321,12 @@ class ApplicationController < ActionController::Base
   end
 
   def common_data_user
-    @common_data_user ||= Carto::User.find_by_username(Cartodb.config[:common_data]["username"])
+    return @common_data_user if @common_data_user
+
+    common_data_config = Cartodb.config[:common_data]
+    username = common_data_config && common_data_config['username']
+
+    @common_data_user = Carto::User.find_by_username(username)
   end
 
   # current_user relies on request subdomain ALWAYS, so current_viewer will always return:

--- a/lib/carto/http_header_authentication.rb
+++ b/lib/carto/http_header_authentication.rb
@@ -85,7 +85,7 @@ module Carto
 
     def header_value(headers)
       header = ::Cartodb.get_config(:http_header_authentication, 'header')
-      puts "user-auto-creation : Trying to extract value from headers for #{header}, value is #{headers[header]}"
+      puts "user-auto-creation : Trying to extract value from headers for #{header}, value is #{headers[header || '']}"
       !header.nil? && !header.empty? ? headers[header] : nil
     end
   end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -31,7 +31,8 @@ def create_import(user, file_name, name=nil)
   end
 
   @data_import.data_source =  file_name
-  @data_import.send :new_importer
+  importer, runner, datasource_provider, manual_fields = @data_import.send(:new_importer)
+  @data_import.send(:execute_importer, importer, runner, datasource_provider, manual_fields)
   @data_import
 end
 

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -143,7 +143,8 @@ module CartoDB
       end
 
       data_import.data_source = file_name
-      data_import.send :new_importer
+      importer, runner, datasource_provider, manual_fields = data_import.send(:new_importer)
+      data_import.send(:execute_importer, importer, runner, datasource_provider, manual_fields)
       data_import
     end
 


### PR DESCRIPTION
## Context

This PR fixes the tests that were broken by the FDW implementation. Coders extracted the `new_importer` method and the tests in `table_spec.rb` where stubbed an weak (they made assumptions on the implementation of `new_importer`). 

The fix is to improve the bad stub. It's not worth it to remove it, since merge code handles importers differently anyway.

There is also one minor mod: the common data user fetch doesn't assume that common data is present in `app_config.yml`.

I've also added protection against empty headers in stdout logger (this is an [old fix](https://github.com/bloomberg/cartodb/pull/136), but it was never merged)