### PR TITLE
Rdsimaps3295 synchronization fixes

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -842,8 +842,8 @@ class DataImport < Sequel::Model
 
       if importer.success?
         update_visualization_id(importer)
-        update_synchronization(importer)
       end
+      update_synchronization(importer)
 
       importer.success? ? set_datasource_audit_to_complete(datasource_provider,
                                                          importer.success? && importer.table ? importer.table.id : nil)


### PR DESCRIPTION
- Set 'queued' state to new synchronization records after they are enqueued onto resque.  This will prevent synchronizations entering an error state where they can no longer be manually synced.
- Update synchronization record state on importer success or failure. 