### PR TITLE
Remove the table scan when exporting a remote dataset

### DIFF
--- a/lib/carto/visualization_exporter.rb
+++ b/lib/carto/visualization_exporter.rb
@@ -13,6 +13,13 @@ module Carto
       table_name = user_table.name
 
       query = %{select * from "#{table_name}"}
+
+      # Hack for Samples 2.0 - Save As.  Allow the SQL API to generate a proper gpkg
+      # but make sure it doesn't do a full table scan
+      if(format == 'gpkg' && is_remote)
+        query << ' limit 0'
+      end
+
       url = sql_api_query_url(query, table_name, user_table.user, privacy(user_table), format)
       exported_file = "#{folder}/#{table_name}.#{format}"
 


### PR DESCRIPTION
Changes the query to return 0 rows.  This change will still use the sql service's functionality of creating a proper gpkg file.  This will provide a speed up for clients in the most common event that sample maps contain common shared datasets.  However if it's necessary to squeeze out more performance we can also add our own logic into editor to create proper gpkg files in the future as well.  

@gfiorav for review as well.