### PR TITLE
Update Makefile for Continuous Integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
 REV=$(shell git rev-parse HEAD)
 RUBY_MAJOR=$(shell ruby -e "puts RUBY_VERSION" | cut -d. -f1)
 
+ifdef JSON_DIR
+  OUT_PFX=--format json --out $(JSON_DIR)
+  OUT_1=$(OUT_PFX)_1.json
+  OUT_2=$(OUT_PFX)_2.json
+  OUT_4=$(OUT_PFX)_4.json
+  OUT_5=$(OUT_PFX)_5.json
+  OUT_7=$(OUT_PFX)_7.json
+  OUT_9=$(OUT_PFX)_9.json
+  OUT_HM=$(OUT_PFX)_hm.json
+  OUT_CDB=$(OUT_PFX)_cdb.json
+endif
+
+
 all:
 	RAILS_ENV=test bundle install
 	# I cannot remmeber why gdal is being skipped from this list...
@@ -336,21 +349,21 @@ endif
 
 # TODO: Ongoing removal of groups, that's the reason of holes in numbering
 check-1:
-	CHECK_SPEC=1 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_1)
+	CHECK_SPEC=1 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_1) $(OUT_1)
 check-2:
-	CHECK_SPEC=2 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_2)
+	CHECK_SPEC=2 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_2) $(OUT_2)
 check-4:
-	CHECK_SPEC=4 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_4)
+	CHECK_SPEC=4 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_4) $(OUT_4)
 check-5:
-	CHECK_SPEC=5 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_5)
+	CHECK_SPEC=5 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_5) $(OUT_5)
 check-7:
-	CHECK_SPEC=7 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_7)
+	CHECK_SPEC=7 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_7) $(OUT_7)
 check-9:
-	CHECK_SPEC=9 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_9)
+	CHECK_SPEC=9 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_9) $(OUT_9)
 check-spec-helper-min:
-	CHECK_SPEC=50 RAILS_ENV=test bundle exec rspec $(SPEC_HELPER_MIN_SPECS)
+	CHECK_SPEC=50 RAILS_ENV=test bundle exec rspec $(SPEC_HELPER_MIN_SPECS) $(OUT_HM)
 check-carto-db-class:
-	CHECK_SPEC=51 RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_carto_db_class)
+	CHECK_SPEC=51 RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_carto_db_class) $(OUT_CDB)
 check-integrations:
 	CHECK_SPEC=52 RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_INTEGRATIONS)
 


### PR DESCRIPTION
Allows writing rspec results to JSON file by passing in JSON_DIR=<path_prefix> as argument. usage: `make check-1 JSON_DIR=/tmp/backend_results`. Result files will be stored as /tmp/backend_results_1.json, /tmp/backend_results_2.json etc