### PR TITLE
View Dataset Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
     url = https://bbgithub.dev.bloomberg.com/datavis-cartodb/cartodb.css.git
 [submodule "lib/sql"]
     path = lib/sql
-    url = https://github.com/CartoDB/cartodb-postgresql.git
+    url = https://github.com/bloomberg/cartodb-postgresql.git
 [submodule "lib/carto_assets"]
     path = lib/carto_assets
     url = https://github.com/bloomberg/CartoAssets.git

--- a/app/controllers/api/json/imports_controller.rb
+++ b/app/controllers/api/json/imports_controller.rb
@@ -195,6 +195,8 @@ class Api::Json::ImportsController < Api::ApplicationController
       append:                 (params[:append].presence == 'true'),
       table_copy:             params[:table_copy].presence,
       from_query:             params[:sql].presence,
+      relation_type:          DataImport::ALLOWED_RELATION_TYPES.include?(params[:relation_type]) ?
+                                  params[:relation_type] : DataImport::RELATION_TYPE_TABLE,
       service_name:           params[:service_name].present? ? params[:service_name] : CartoDB::Datasources::Url::PublicUrl::DATASOURCE_NAME,
       service_item_id:        params[:service_item_id].present? ? params[:service_item_id] : params[:url].presence,
       type_guessing:          !["false", false].include?(params[:type_guessing]),

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,7 @@ class HomeController < ApplicationController
   PG_VERSION = 'PostgreSQL 9.5'.freeze
   POSTGIS_VERSION = '2.2'.freeze
   CDB_VALID_VERSION = '0.18'.freeze
-  CDB_LATEST_VERSION = '0.18.5'.freeze
+  CDB_LATEST_VERSION = '0.18.6'.freeze
   REDIS_VERSION = '3'.freeze
   RUBY_BIN_VERSION = 'ruby 2.2.3'.freeze
   NODE_VERSION = 'v0.10'.freeze

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -60,14 +60,16 @@ module CartoDB
         # table `table_name`, with the imported contents, i.e.
         # `result.table_name`.  This may be optimized as a DROP
         # and RENAME if the table can be dropped, otherwise a
-        # truncate-insert is performed.
+        # TRUNCATE/INSERT is performed.
         database.execute(%Q{
-          SELECT cartodb.CDB_TableUtils_ReplaceTableContents(
-            '#{user.database_schema}',
-            '#{table_name}',
-            '#{result.table_name}',
-            '#{temporary_name}'
-          );
+          BEGIN TRANSACTION;
+            SELECT cartodb.CDB_TableUtils_ReplaceTableContents(
+              '#{user.database_schema}',
+              '#{table_name}',
+              '#{result.table_name}',
+              '#{temporary_name}'
+            );
+          COMMIT;
         })
         fix_oid(table_name)
         update_cdb_tablemetadata(table_name)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1176,10 +1176,16 @@ class Table
     schema_name = owner.database_schema
     table_name = "#{owner.database_schema}.#{self.name}"
 
+    cartodbfy_proc = case (@data_import && @data_import.relation_type)
+      when ::DataImport::RELATION_TYPE_TABLE then 'CDB_CartodbfyTable'
+      when ::DataImport::RELATION_TYPE_VIEW  then 'CDB_CartodbfyView'
+      else 'CDB_CartodbfyTable'
+    end
+
     importer_stats.timing('cartodbfy') do
       owner.transaction_with_timeout(statement_timeout: STATEMENT_TIMEOUT) do |user_conn|
         user_conn.run(%Q{
-          SELECT cartodb.CDB_CartodbfyTable('#{schema_name}'::TEXT,'#{table_name}'::REGCLASS);
+          SELECT cartodb.#{cartodbfy_proc}('#{schema_name}'::TEXT,'#{table_name}'::REGCLASS);
         })
       end
     end

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -530,7 +530,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.18.5'
+          cdb_extension_target_version = '0.18.6'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|

--- a/db/migrate/20180117160142_add_relation_type_to_data_imports.rb
+++ b/db/migrate/20180117160142_add_relation_type_to_data_imports.rb
@@ -1,0 +1,19 @@
+require 'carto/db/migration_helper'
+
+include Carto::Db::MigrationHelper
+
+migration(
+  # up
+  Proc.new do
+    alter_table :data_imports do
+      add_column :relation_type, :text, null: false, default: 'table'
+    end
+  end,
+  # down
+  Proc.new do
+    alter_table :data_imports do
+      drop_column :relation_type
+    end
+  end
+)
+

--- a/lib/assets/javascripts/cartodb/common/dialogs/duplicate_dataset_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/duplicate_dataset_view.js
@@ -44,13 +44,18 @@ module.exports = BaseDialog.extend({
 
   _duplicateDataset: function(newName) {
     var self = this;
+    var options = {};
+    if (this.options.relation_type) {
+      options.relation_type = this.options.relation_type;
+    }
+
     var newName = this.model.get('name') + '_copy';
     this.model.duplicate(newName, {
       success: function(newTable) {
         self._redirectTo(newTable.viewUrl());
       },
       error: self._showError.bind(self)
-    });
+    }, options);
   },
 
   _showError: function(model) {

--- a/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/choose_key_columns_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/choose_key_columns_view.js
@@ -50,7 +50,7 @@ module.exports = cdb.core.View.extend({
     this.addView(this._leftColumnsView);
 
     var mergeNonExportableDatasetsEnabled = this.model.get('user') &&
-      this.model.get('user').featureEnabled('merge_non_exportable_datasets_enabled');
+      this.model.get('user').featureEnabled('merge_non_exportable_datasets');
     this._rightTableSelectorView = new TablesSelectorView({
       excludeFilter: function(vis) {
         return (!vis.get('exportable') && !mergeNonExportableDatasetsEnabled)

--- a/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/choose_key_columns_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/choose_key_columns_view.js
@@ -49,9 +49,12 @@ module.exports = cdb.core.View.extend({
     });
     this.addView(this._leftColumnsView);
 
+    var mergeNonExportableDatasetsEnabled = this.model.get('user') &&
+      this.model.get('user').featureEnabled('merge_non_exportable_datasets_enabled');
     this._rightTableSelectorView = new TablesSelectorView({
       excludeFilter: function(vis) {
-        return !vis.get('exportable') || vis.get('name') === leftTableName;
+        return (!vis.get('exportable') && !mergeNonExportableDatasetsEnabled)
+            || vis.get('name') === leftTableName;
       }
     });
     this.addView(this._rightTableSelectorView);

--- a/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/generate_column_merge_sql.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/generate_column_merge_sql.js
@@ -2,7 +2,7 @@ var _ = require('underscore-cdb-v3');
 
 // Used for both left and right table
 var selectColumn = function(tableName, otherTableName, columnName) {
-  if (columnName === 'the_geom') {
+  if (columnName === 'the_geom' || columnName === 'the_geom_webmercator') {
     return [
       'CASE WHEN ' + tableName + '.' + columnName + ' IS NULL THEN',
       otherTableName + '.' + columnName,

--- a/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/select_columns_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/select_columns_model.js
@@ -58,15 +58,26 @@ module.exports = cdb.core.Model.extend({
     var leftKeyColumn = this.get('leftKeyColumn');
     var rightKeyColumn = this.get('rightKeyColumn');
 
+    var selectedLeftColumnNames = this._selectedColumnsNamesFor('leftColumns');
+    var selectedRightColumnNames = this._selectedColumnsNamesFor('rightColumns');
+
+    // Also copy the_geom_webmercator from view with the_geom
+    if (_.contains(selectedLeftColumnNames, 'the_geom')) {
+      selectedLeftColumnNames.push('the_geom_webmercator');
+    }
+    else if (_.contains(selectedRightColumnNames, 'the_geom')) {
+      selectedRightColumnNames.push('the_geom_webmercator');
+    }
+
     var sql = generateColumnMergeSQL({
       leftTableName: this.get('leftTable').get('name'),
       leftKeyColumnName: leftKeyColumn.get('name'),
       leftKeyColumnType: leftKeyColumn.get('type'),
-      leftColumnsNames: this._selectedColumnsNamesFor('leftColumns'),
+      leftColumnsNames: selectedLeftColumnNames,
       rightTableName: this.get('rightTableData').name,
       rightKeyColumnName: rightKeyColumn.get('name'),
       rightKeyColumnType: rightKeyColumn.get('type'),
-      rightColumnsNames: this._selectedColumnsNamesFor('rightColumns')
+      rightColumnsNames: selectedRightColumnNames
     });
 
     return new this.constructor.nextStep({

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -874,13 +874,18 @@
      * @param {Object} callbacks
      * @returns {Object}
      */
-    duplicate: function(newName, callbacks) {
+    duplicate: function(newName, callbacks, options) {
       callbacks = callbacks || {};
+      options = options || {};
 
       // Extracted from duplicate_table_dialog
       var data = {
         table_name: newName
       };
+
+      if (options.relation_type) {
+        data.relation_type = options.relation_type;
+      }
 
       // Set correct data object, depending on if the app has a query applied or not
       if (this.isInSQLView()) {

--- a/lib/assets/javascripts/cartodb/table/header/options_menu.js
+++ b/lib/assets/javascripts/cartodb/table/header/options_menu.js
@@ -27,6 +27,7 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
     'click .export_map':      '_exportMap',
     'click .export_table':    '_exportTable',
     'click .duplicate_table': '_duplicateDataset',
+    'click .duplicate_view': '_duplicateDatasetAsView',
     'click .duplicate_vis':   '_duplicateVis',
     'click .append_data':     '_appendData',
     'click .delete_table':    '_deleteItem',
@@ -161,6 +162,21 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
       model: this.table,
       user: this.user,
       clean_on_hide: true
+    });
+    dialog.appendToBody();
+  },
+
+  /**
+   *  Duplicate dataset as view
+   */
+  _duplicateDatasetAsView: function(e){
+    e.preventDefault();
+
+    var dialog = new cdb.editor.DuplicateDatasetView({
+      model: this.table,
+      user: this.user,
+      clean_on_hide: true,
+      relation_type: 'view',
     });
     dialog.appendToBody();
   },

--- a/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
@@ -1,5 +1,5 @@
 <% var bbgProUI = $.inArray("bbg_pro_ui", user_data.feature_flags) !== -1; %>
-<% var viewDatasetsEnabled = $.inArray("bbg_view_datasets", user_data.feature_flags) !== -1; %>
+<% var viewDatasetsEnabled = $.inArray("datasets_as_views", user_data.feature_flags) !== -1; %>
 <ul>
   <% if (!isVisualization) { %>
     <li class="<% if (table.isInSQLView() && dataLayer && !dataLayer.get('query')) { %>disabled<% } %>"><a class="small export_table" href="#/export">Export...</a></li>

--- a/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
@@ -1,11 +1,15 @@
 <% var bbgProUI = $.inArray("bbg_pro_ui", user_data.feature_flags) !== -1; %>
+<% var viewDatasetsEnabled = $.inArray("bbg_view_datasets", user_data.feature_flags) !== -1; %>
 <ul>
   <% if (!isVisualization) { %>
     <li class="<% if (table.isInSQLView() && dataLayer && !dataLayer.get('query')) { %>disabled<% } %>"><a class="small export_table" href="#/export">Export...</a></li>
 
     <% if (table.isInSQLView()) { %>
       <% if (!table.isSync()) { %>
-        <li><a class="small duplicate_table" href="#/table-from-query">Dataset from query</a></li>
+        <li><a class="small duplicate_table" href="#/table-from-query">Table dataset from query</a></li>
+      <% } %>
+      <% if (viewDatasetsEnabled) { %>
+        <li><a class="small duplicate_view" href="#/view-from-query">View dataset from query</a></li>
       <% } %>
     <% } else { %>
       <li class="<% if (table.isSync()) { %>disabled<% } %>">


### PR DESCRIPTION
# Purpose

Enable creation of datasets as views instead of as tables using the imports API.

## Import API Changes

This introduces the `relation_type` parameter to the imports API, which is only considered when importing from a query.  It accepts the values `table` and `view`, and defaults to `table`.  If `view` is passed, the resulting dataset will have the following characteristics:
- The dataset is not updatable
- Any data pulled by the view from other tables is always live.
- The query is performed up to once per tile request, and potentially many more times by the editor, so performance considerations should be made when composing a view's query.
- Any time the table dependencies of a view are updated, the systems which bust caches for queries referencing database objects now respect datasets implemented as views, so that stale query results will not be served.

## Editor UI Changes

Partial support for creation of views through the UI has also been added, namely
- A _**View Dataset from Query**_ Action in the dataset editing mode.  This imports the current query in the SQL editor as a view dataset.  This action requires the `bbg_view_datasets` feature flag.
- Additional options and optimizations for the _**Merge Dataset**_ wizard, including reusing `the_geom_webmercator` column from the dataset providing `the_geom` and the ability to merge non-exportable datasets with the `merge_non_exportable_datasets_enabled` feature flag.