### PR TITLE
Add new sample_link route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/models/carto/username_proposer_spec.rb \
 	spec/services/carto/overquota_users_service_spec.rb \
 	spec/lib/carto/geopkg_carto_metadata_util_spec.rb \
+	spec/requests/carto/api/samples_controller_spec.rb \
 	$(NULL)
 
 # This class must be tested isolated as pollutes namespace

--- a/app/controllers/carto/api/samples_controller.rb
+++ b/app/controllers/carto/api/samples_controller.rb
@@ -1,6 +1,9 @@
+require_dependency 'carto/uuidhelper'
+
 module Carto
   module Api
     class SamplesController < ::Api::ApplicationController
+      include Carto::UUIDHelper
 
       ssl_required :show
 

--- a/app/controllers/carto/api/samples_controller.rb
+++ b/app/controllers/carto/api/samples_controller.rb
@@ -1,0 +1,31 @@
+module Carto
+  module Api
+    class SamplesController < ::Api::ApplicationController
+
+      ssl_required :show
+
+      # TODO: compare with older, there seems to be more optional authentication endpoints
+      before_filter :id_and_schema_from_params
+
+      rescue_from Carto::LoadError, with: :rescue_from_carto_error
+      rescue_from Carto::UUIDParameterFormatError, with: :rescue_from_carto_error
+
+      def show
+        # Lookup visualization
+        viz = Carto::Visualization.where(id: @id).first
+        if viz && viz.user_id == sample_maps_user.id
+           redirect_to CartoDB.url(self, 'public_visualizations_sample_map', { id: params[:id], sample_user: sample_maps_user.username }, current_user)
+        else
+          # Re-route to default page and show error message
+          redirect_to CartoDB.url(self, 'maps_samples', {}, current_user)
+        end
+      rescue KeyError
+        head(404)
+      end
+
+      def id_and_schema_from_params
+        @id = params.fetch('id', nil)
+      end
+    end
+  end
+end

--- a/app/controllers/carto/api/samples_controller.rb
+++ b/app/controllers/carto/api/samples_controller.rb
@@ -11,6 +11,12 @@ module Carto
       rescue_from Carto::UUIDParameterFormatError, with: :rescue_from_carto_error
 
       def show
+        # Validate if valid uuid
+        unless is_uuid?(@id)
+          redirect_to CartoDB.url(self, 'maps_samples', {}, current_user)
+          return
+        end
+
         # Lookup visualization
         viz = Carto::Visualization.where(id: @id).first
         if viz && viz.user_id == sample_maps_user.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -464,6 +464,9 @@ CartoDB::Application.routes.draw do
 
     # ImageProxy
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/image_proxy' => 'image_proxy#show'
+
+    # Samples Link - Bloomberg specific
+    get '(/user/:user_domain)(/u/:user_domain)/api/v1/sample_link/:id' => 'samples#show', as: :api_v1_samples_link_show
   end
 
   scope :module => 'api/json', :format => :json do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -466,7 +466,7 @@ CartoDB::Application.routes.draw do
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/image_proxy' => 'image_proxy#show'
 
     # Samples Link - Bloomberg specific
-    get '(/user/:user_domain)(/u/:user_domain)/api/v1/sample_link/:id' => 'samples#show', as: :api_v1_samples_link_show
+    get '(/user/:user_domain)(/u/:user_domain)/api/v1/sample_link/:id' => 'samples#show', as: :api_v1_samples_link_show, constraints: { id: /[^\/]+/ }
   end
 
   scope :module => 'api/json', :format => :json do

--- a/spec/requests/carto/api/samples_controller_spec.rb
+++ b/spec/requests/carto/api/samples_controller_spec.rb
@@ -1,0 +1,66 @@
+# encoding: utf-8
+
+require_relative '../../../spec_helper'
+require 'factories/carto_visualizations'
+require_relative '../../../../app/controllers/carto/api/samples_controller'
+
+describe Carto::Api::SamplesController do
+  include Carto::Factories::Visualizations
+
+  before(:all) do
+    @not_sample_user = FactoryGirl.create(:carto_user)
+    @sample_user = FactoryGirl.create(:carto_user, { username: Cartodb.config[:map_samples]['username'] } )
+  end
+
+  before(:each) do
+    bypass_named_maps
+    @headers = {
+      'CONTENT_TYPE' => 'application/json'
+    }
+    host! "#{@not_sample_user.subdomain}.localhost.lan"
+  end
+
+  after(:all) do
+    bypass_named_maps
+    @sample_user.destroy
+    @not_sample_user.destroy
+  end
+
+  let(:params) { { :api_key => @not_sample_user.api_key } }
+
+  describe 'GET /api/v1/sample_link/:id' do
+    it 'opens sample map with valid id' do
+      map, table, table_visualization, visualization = create_full_visualization(@sample_user)
+      begin
+        get api_v1_samples_link_show_url(params.merge(id: visualization.id)), {}, @headers
+        expect(response.status).to eq(302) # Re-direct
+        expect(response.location).to eq(public_visualizations_sample_map_url({id: visualization.id, sample_user: @sample_user.username, port: 53716}))
+      ensure
+        destroy_full_visualization(map, table, table_visualization, visualization)
+      end
+    end
+
+    it 'opens data library to sample map view with non-sample user id' do
+        map, table, table_visualization, visualization = create_full_visualization(@not_sample_user)
+      begin
+        get api_v1_samples_link_show_url(params.merge(id: visualization.id)), {}, @headers
+        expect(response.status).to eq(302) # Re-direct
+        expect(response.location).to eq(maps_samples_url(port: 53716))
+      ensure
+        destroy_full_visualization(map, table, table_visualization, visualization)
+      end
+    end
+
+    it 'opens data library to sample map view with non-existent id' do
+      get api_v1_samples_link_show_url(params.merge(id: '00011000-0000-0000-0000-000100010001')), nil, @headers
+      expect(response.status).to eq(302) # Re-direct
+      expect(response.location).to eq(maps_samples_url(port: 53716))
+    end
+
+    it 'opens data library to sample map view with invalid uuid format id' do
+      get api_v1_samples_link_show_url(params.merge(id: 'deadbeef')), nil, @headers
+      expect(response.status).to eq(302) # Re-direct
+      expect(response.location).to eq(maps_samples_url(port: 53716))
+    end
+  end
+end


### PR DESCRIPTION
The sample_link route will be the url used when users run MAPS in the terminal with the sample map link (aka the SAMPLE tail)