### PR TITLE
Export Image Fixes

### DIFF
--- a/app/assets/stylesheets/table/export_image_view.css.scss
+++ b/app/assets/stylesheets/table/export_image_view.css.scss
@@ -157,7 +157,7 @@
 .ExportHelperDescription {
   color: #FFF;
   font-size: 13px;
-  line-height: 19px;
+  line-height: normal;
   width: 100%;
 }
 

--- a/lib/assets/javascripts/cartodb/table/export_image_view.js
+++ b/lib/assets/javascripts/cartodb/table/export_image_view.js
@@ -73,7 +73,7 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
           var extras = header.attributes.options.extra;
           if (extras.headerType == 'title') {
 
-            self.options.title = extras.text;
+            self.options.title = extras.rendered_text;
             self.options.show_title = true;
 
             // Store reference to title overlay for later use
@@ -81,7 +81,7 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
 
           } else if (extras.headerType == 'description') {
 
-            self.options.description = extras.text;
+            self.options.description = extras.rendered_text;
             self.options.show_description = true;
 
             // Store reference to description overlay for later use

--- a/lib/assets/javascripts/cartodb/table/views/export_image_view.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/export_image_view.jst.ejs
@@ -6,7 +6,7 @@
   <% if (show_title || show_description) { %>
   <div class="ExportHelper ExportHelper--header">
     <% if (show_title) { %>
-    <div class="ExportHelperTitle js-title"><%- title %></div>
+    <div class="ExportHelperTitle js-title"><%= cdb.core.sanitize.html(title) %></div>
     <% } %>
     <% if (show_description) { %>
     <div class="ExportHelperDescription js-description"><%= cdb.core.sanitize.html(description) %></div>


### PR DESCRIPTION
# Purpose

These changes fix two bugs in the Export Image workflow

### _Fixed Description Line Height_
The `line-height` property of the `.ExportHelperDescription` class, which styles the fixed description in the export image view, is hard coded to a fixed `19px`.  This causes vertical overlap of text when the font is sufficiently large and the text spans multiple lines.  This change sets the `line-height` to `normal` to match the fixed description overlay in the map editor view.

### _HTML Formatting Improperly Escaped_
Overlays support markdown formatting which is rendered as html.  Both the rendered html and markdown source are stored in the `options` column of the `overlays` table as `rendered_text` and `text`, respectively.

Previously, the markdown source, not the rendered html, was injected into the export image view template, and was only escaped as html in the case of the description.  This change ensures that the stored html for the overlay is always sanitized and not escaped by the template.