### PR TITLE
Export image in current tab

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.jst.ejs
@@ -1,3 +1,4 @@
+<% var export_image_in_new_tab = $.inArray("export_image_in_new_tab", user_data.feature_flags) !== -1; %>
 <div class="u-inner" style="display: none;">
   <div class="Dialog-header">
     <div class="Dialog-headerIcon Dialog-headerIcon--neutral">
@@ -7,7 +8,8 @@
     <% if (response.type === 'url') {%>
     <p class="Dialog-headerText">It's now available in: <a href="<%- response.content %>"
         id="download_link"
-        target="_blank" class="ExportImageResult--url" download="<%- response.filename %>"><%- response.displayedLink %></a></p>
+        <% export_image_in_new_tab ? 'target="_blank"' : '' %>
+        class="ExportImageResult--url" download="<%- response.filename %>"><%- response.displayedLink %></a></p>
     <% } else { %>
     <p class="Dialog-headerText">To embed it in your website, use the code below</p>
   </div>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.46",
+  "version": "4.6.47",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.46",
+  "version": "4.6.47",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Background

The previous behavior of the export image dialog
was to open the exported image for download in a
new tab by specifying target="_blank" on the down-
load link.  This worked fine before Chrome 65, at
which point the behavior changed such that the
popup was blocked by default, and triggered a new
code path in the chromium wrapper for handling
links which was subject to crashes.  Removing
target="_blank" from the download link forces the
download to be processed in the current tab, and
bypasses the problematic code path in our chromium
wrapper. This change may be backed by creating the
unrestricted feature flag 'export_image_in_new_tab'.