### PR TITLE
Fix the failure for config endpoint with Postgis Plugin Error

### DIFF
--- a/lib/assets/javascripts/cartodb/models/cartodb_layer.js
+++ b/lib/assets/javascripts/cartodb/models/cartodb_layer.js
@@ -241,13 +241,14 @@ cdb.admin.CartoDBLayer = cdb.geo.CartoDBLayer.extend({
       options: c,
       order: c.order,
       infowindow: null,
-      tooltip: this.tooltip.toJSON()
+      tooltip: null
     };
 
-    // Don't send infowindow data if wizard doesn't support it
+    // Don't send infowindow/tooltip data if wizard doesn't support it
     // It will make the tiler fails
     if (this.wizard_properties.supportsInteractivity()) {
       d.infowindow = this.infowindow.toJSON();
+      tooltip = this.tooltip.toJSON();
     }
 
     if(c.id !== undefined) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.47",
+  "version": "4.6.48",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.47",
+  "version": "4.6.48",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Which results in the failure for the image export. 
The typical error message looks like below:
Postgis Plugin: ERROR: column xyz does not exist LINE 1: 
Workaround:
Change the visulization to the category, remove the hover interactivity for the tooltip and change visualization back to cluster.