### PR TITLE
Increase concurrent syncs per user

### DIFF
--- a/services/platform-limits/lib/importer/user_concurrent_syncs_amount.rb
+++ b/services/platform-limits/lib/importer/user_concurrent_syncs_amount.rb
@@ -13,7 +13,7 @@ module CartoDB
         # In seconds
         KEY_TTL = 2*60*60
 
-        MAX_SYNCS_PER_USER = 15
+        MAX_SYNCS_PER_USER = 30
 
         # Sync load necessary to generate warning logs
         SYNC_LOAD_WARNING_THRESHOLD = 0.80


### PR DESCRIPTION
# Purpose

The current sync limit is insufficient for periods of high load - this increases that limit.  Tested in dev to confirm that the sync could handle 30 concurrent syncs.