### PR TITLE
Disable test quota per row

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,7 @@ class HomeController < ApplicationController
   PG_VERSION = 'PostgreSQL 9.5'.freeze
   POSTGIS_VERSION = '2.2'.freeze
   CDB_VALID_VERSION = '0.18'.freeze
-  CDB_LATEST_VERSION = '0.18.6'.freeze
+  CDB_LATEST_VERSION = '0.18.7'.freeze
   REDIS_VERSION = '3'.freeze
   RUBY_BIN_VERSION = 'ruby 2.2.3'.freeze
   NODE_VERSION = 'v0.10'.freeze

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -101,6 +101,8 @@ module CartoDB
         # `result.table_name`.  This may be optimized as a DROP
         # and RENAME if the table can be dropped, otherwise a
         # TRUNCATE/INSERT is performed.
+
+        disable_test_quota_per_row = user.has_feature_flag? 'disable_test_quota_per_row_for_syncs'
         log_params = "table_name: #{table_name}"
         message = "#{self.class.name}#overwrite#replace_table_contents {#{log_params}}"
         CartoDB::Logger.debug_time(message: message, user: user, table_name: table_name) do
@@ -110,7 +112,8 @@ module CartoDB
                 '#{user.database_schema}',
                 '#{table_name}',
                 '#{result.table_name}',
-                '#{temporary_name}'
+                '#{temporary_name}',
+                #{disable_test_quota_per_row ? 'true' : 'false'}
               );
             COMMIT;
           })

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -533,7 +533,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.18.6'
+          cdb_extension_target_version = '0.18.7'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|


### PR DESCRIPTION
# Purpose

* Enable toggling of per row quota check during syncs for individual users
* Depends on v0.18.7 of cartodb-postgresql, introduced with https://github.com/bloomberg/cartodb-postgresql/pull/2