### PR TITLE
replace . with _ in the filename during export

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
@@ -58,7 +58,7 @@ module.exports = BaseDialog.extend({
 
   _generateImageFilename: function() {
     var filename = this.vis.get('name');
-    return filename.replace(/ /g, '_').toLowerCase();
+    return filename.replace(/ |\./g, '_').toLowerCase();
   },
 
   generateImage: function(url) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.50",
+  "version": "4.6.51",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.50",
+  "version": "4.6.51",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Any '.' character in the map title messes up the the export file name, so changing it to _.