### PR TITLE
Set ogr2ogr auto-detect size limit to the whole file

### DIFF
--- a/services/importer/lib/importer/ogr2ogr.rb
+++ b/services/importer/lib/importer/ogr2ogr.rb
@@ -164,6 +164,7 @@ module CartoDB
           # Inverse of the selection: if I want guessing I must NOT leave quoted fields as string
           [
             '-oo', 'AUTODETECT_TYPE=YES',
+            '-oo', 'AUTODETECT_SIZE_LIMIT=0',
             '-oo', "QUOTED_FIELDS_AS_STRING=#{quoted_fields_guessing ? 'NO' : 'YES'}"
           ] + x_y_possible_names_option + ['-s_srs', 'EPSG:4326', '-t_srs', 'EPSG:4326']
         end


### PR DESCRIPTION
Prior to this change, only the first 100,000 bytes of the input
file were scanned to detect field types. This led to incorrect
behavior when a dummy row was added at the end to force a numeric
field to treated as text.

This change removes the scan limit to resolve the problem at the
expense of potentially slowing down large imports.