### PR TITLE
Make extension upgrade procedure more robust

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,7 @@ class HomeController < ApplicationController
   PG_VERSION = 'PostgreSQL 9.5'.freeze
   POSTGIS_VERSION = '2.2'.freeze
   CDB_VALID_VERSION = '0.18'.freeze
-  CDB_LATEST_VERSION = '0.18.10'.freeze
+  CDB_LATEST_VERSION = '0.18.9'.freeze
   REDIS_VERSION = '3'.freeze
   RUBY_BIN_VERSION = 'ruby 2.2.3'.freeze
   NODE_VERSION = 'v0.10'.freeze

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -533,7 +533,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.18.10'
+          cdb_extension_target_version = '0.18.9'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -116,7 +116,7 @@ module CartoDB
         Thread.new do
           create_db_user
         end.join
-        create_own_schema
+        create_own_schema(load_cartodb_extension: false)
 
         # WIP: CartoDB/cartodb-management#4467
         # Added after commenting it in setup_organization_user_schema to avoid configure_database to reset permissions
@@ -1034,8 +1034,8 @@ module CartoDB
         end
       end
 
-      def create_own_schema
-        load_cartodb_functions
+      def create_own_schema(load_cartodb_extension: true)
+        load_cartodb_functions(nil, nil, load_cartodb_extension, true)
         @user.database_schema = @user.username
         @user.this.update(database_schema: @user.database_schema)
         create_user_schema


### PR DESCRIPTION
# Scope

While planning an upgrade of the cartodb sql extension version, a couple of flaws of varying severity were discovered in the existing upgrade procedure was discovered.  Unfortunately, these flaws can't be fixed by simply changing the deployment procedure, thus code changes are introduced to make this upgrade process more robust.  Details of each flaw are listed below.

Additionally, in order to ensure proper rollout of the next extension version, `0.18.10`, these logic updates must first be applied to resques targeting the previous extension version `0.18.9`.  Thus this change backs out the upgrade of the extension version.

### _User creation triggering extension upgrade_

Each time an org user is created, the CREATE/UPDATE extension logic is invoked.  While this may be useful for dedicated users, it is not necessary for org users and may cause unwanted upgrades of the extension.  As soon as a new extension version is installed onto the database server and a new resque deployed with the updated extension version, any org user creation will trigger an upgrade of the extension version for the entire org db.  Since rake tasks exist to upgrade all user databases in a controlled manner, the logic to automatically update these databases upon some user action is removed.

### _User creation triggering extension upgrade causing failure_

During an extension upgrade, it is also possible for a user creation to attempt a downgrade of the extension version, from the new to the previous.  This occurs when a resque targeting the older extension version process a user creation after the db has already been upgraded.  Though unlikely in practice, it's not possible to protect against this condition during an upgrade with the current logic without downtime during the resque deployment.  Because resques operate like offline workers as opposed to services, old resques must always coexist with new resques during a deployment.  Thus, the downgrade is prevented by not modifying the extension at all during user creations.

# Rollout Plan

1. Perform a new editor and resque release from this PR
1. Follow up with another PR to reapply extension version `0.18.10`.
