### PR TITLE
Re-upgrade to cartodb-postgresql 0.18.10

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,7 @@ class HomeController < ApplicationController
   PG_VERSION = 'PostgreSQL 9.5'.freeze
   POSTGIS_VERSION = '2.2'.freeze
   CDB_VALID_VERSION = '0.18'.freeze
-  CDB_LATEST_VERSION = '0.18.9'.freeze
+  CDB_LATEST_VERSION = '0.18.10'.freeze
   REDIS_VERSION = '3'.freeze
   RUBY_BIN_VERSION = 'ruby 2.2.3'.freeze
   NODE_VERSION = 'v0.10'.freeze

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -533,7 +533,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.18.9'
+          cdb_extension_target_version = '0.18.10'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|


### PR DESCRIPTION
# Purpose

Re-upgrade to 0.18.10 after the extension upgrade logic change introduced by https://github.com/bloomberg/cartodb/pull/367.  This will follow as a separate deployment.